### PR TITLE
Fixes 404'd link to 'learn/network'

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ title: Fluent OpenStack client for Java
 	<div class="span4 multi-items">
 	  <div class="imageLabel"><span class="glyphicon glyphicon-signal"></span> Network</div>
       <p>The Network (Neutron) service provides "network connectivity as a service".  The OpenStack4j implementation supports Routers, Ports, Subnets and Interface management.</p>
-      <p><a href="/learn/networks" class="btn btn-xs btn-inverse"><span class="glyphicon glyphicon-book"> </span> Network Guide</a></p>
+      <p><a href="/learn/network" class="btn btn-xs btn-inverse"><span class="glyphicon glyphicon-book"> </span> Network Guide</a></p>
     </div>
 	<div class="span4 multi-items">
 	  <div class="imageLabel"><span class="glyphicon glyphicon-hdd"></span> Block Storage</div>


### PR DESCRIPTION
Link to "/learn/network" was incorrectly "/learn/network**s**"
