### PR TITLE
Fix Javadoc link on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ title: Fluent OpenStack client for Java
 		<span style="margin-left:30px;">
           <a href="/learn" class="btn btn-default btn-success btn-lg"><span class="glyphicon glyphicon-book"> </span>
               Docs</a>
-          <a href="/javadoc" class="btn btn-default btn-info btn-lg" target="_blank"><span
+          <a href="/javadoc/" class="btn btn-default btn-info btn-lg" target="_blank"><span
                   class="glyphicon glyphicon-info-sign"> </span> JavaDoc</a>
           <a href="/learn/getting-started" class="btn btn-warning btn-lg"><span
                   class="glyphicon glyphicon-save"> </span> Install</a>


### PR DESCRIPTION
Without the final "/" on javadoc URL, frames are broken
