### PR TITLE
Point users to new upstream repository: openstack4j/openstack4j

### DIFF
--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta http-equiv="refresh" content="0; URL=https://openstack4j.github.io/">
+    <link rel="canonical" href="https://openstack4j.github.io/">
 	<meta name="msvalidate.01" content="7241C7220434CF221FAA89EEBBCA488F" />
     <meta charset="utf-8">
     <title>OpenStack4j - {{ page.title }}</title>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta http-equiv="refresh" content="0; URL=https://openstack4j.github.io/">
+    <link rel="canonical" href="https://openstack4j.github.io/">
 	<meta name="msvalidate.01" content="7241C7220434CF221FAA89EEBBCA488F" />
     <meta charset="utf-8">
    	<title>OpenStack4j - {{ page.title }}</title>

--- a/_layouts/pages.html
+++ b/_layouts/pages.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta http-equiv="refresh" content="0; URL=https://openstack4j.github.io/">
+    <link rel="canonical" href="https://openstack4j.github.io/">
 	<meta name="msvalidate.01" content="7241C7220434CF221FAA89EEBBCA488F" />
     <meta charset="utf-8">
    	<title>OpenStack4j - {{ page.title }}</title>


### PR DESCRIPTION
We are continuing the project development in [openstack4j/openstack4j](https://github.com/openstack4j/openstack4j/) for the lack of traction here[1]. I am filing this to help users to easily locate the active upstream.

@auhlig, @gondor, please have a look. I would appreciate if you would integrate this.

I have verified this works on github pages. It will effectively redirect all pages.

[1] https://groups.google.com/forum/#!topic/openstack4j/pY2eee760QQ